### PR TITLE
feat: add read functions to market

### DIFF
--- a/abis/market_abi/src/abi.sw
+++ b/abis/market_abi/src/abi.sw
@@ -113,7 +113,7 @@ abi Market {
     fn get_user_basic(account: Address) -> UserBasic;
 
     #[storage(read)]
-    fn get_user_basic_with_interest(account: Address) -> UserBasic;
+    fn get_user_balance_with_interest(account: Address) -> I256;
 
     #[storage(read)]
     fn get_utilization() -> u256;

--- a/libs/market_sdk/src/market_utils.rs
+++ b/libs/market_sdk/src/market_utils.rs
@@ -651,16 +651,16 @@ impl MarketContract {
             .await?)
     }
 
-    pub async fn get_user_basic_with_interest(
+    pub async fn get_user_balance_with_interest(
         &self,
         address: Address,
-    ) -> anyhow::Result<CallResponse<UserBasic>> {
+    ) -> anyhow::Result<CallResponse<I256>> {
         let tx_policies = TxPolicies::default().with_script_gas_limit(DEFAULT_GAS_LIMIT);
 
         Ok(self
             .instance
             .methods()
-            .get_user_basic_with_interest(address)
+            .get_user_balance_with_interest(address)
             .with_tx_policies(tx_policies)
             .call()
             .await?)


### PR DESCRIPTION
### Adds:
- `get_all_user_collateral` -> Returns how much of each collateral a user has deposited
- `get_market_basics_with_interest` -> Market state with interest accrued
- `get_user_basic_with_interest` -> User state with interest accrued (principal is now the present value)