### PR TITLE
fix: error msg & repay amount error

### DIFF
--- a/apps/frontend/src/components/InputDialog/index.tsx
+++ b/apps/frontend/src/components/InputDialog/index.tsx
@@ -428,17 +428,37 @@ export const InputDialog = () => {
 
       // Balance more than user borrowed
       if (userSupplyBorrow.borrowed.eq(0)) return 'You have no debt';
-      const userBorrowed =
-        formatUnits(
-          userSupplyBorrow.borrowed,
-          marketConfiguration?.baseTokenDecimals
-        ).plus(
-          BigNumber(0.02).div(
+
+      const userBorrowed = formatUnits(
+        userSupplyBorrow.borrowed,
+        marketConfiguration?.baseTokenDecimals
+      );
+
+      const userBorrowedModified =
+        userBorrowed.plus(
+          BigNumber(0.002).div(
             priceData?.prices[marketConfiguration.baseToken.bits] ?? 1
           )
         ) ?? BigNumber(0);
 
-      if (tokenAmount.gt(userBorrowed))
+      const userBorrowedModifiedRepay =
+        userBorrowed
+          .plus(
+            BigNumber(0.001).div(
+              priceData?.prices[marketConfiguration.baseToken.bits] ?? 1
+            )
+          )
+          .decimalPlaces(marketConfiguration?.baseTokenDecimals) ??
+        BigNumber(0);
+
+      if (
+        userBorrowedModifiedRepay.minus(tokenAmount).lt(10) &&
+        userBorrowedModifiedRepay.minus(tokenAmount).gt(0)
+      ) {
+        return 'Your position cannot be less than $10. Please repay whole position or leave a position of at least $10 open.';
+      }
+
+      if (tokenAmount.gt(userBorrowedModified))
         return 'You are trying to repay more than your debt';
     }
 

--- a/apps/frontend/src/components/InputDialog/index.tsx
+++ b/apps/frontend/src/components/InputDialog/index.tsx
@@ -34,7 +34,7 @@ import {
   selectTokenAmount,
   useMarketStore,
 } from '@/stores';
-import { formatUnits, getFormattedNumber } from '@/utils';
+import { SYMBOL_TO_NAME, formatUnits, getFormattedNumber } from '@/utils';
 import { useAccount, useIsConnected } from '@fuels/react';
 import * as VisuallyHidden from '@radix-ui/react-visually-hidden';
 import BigNumber from 'bignumber.js';
@@ -451,11 +451,15 @@ export const InputDialog = () => {
           .decimalPlaces(marketConfiguration?.baseTokenDecimals) ??
         BigNumber(0);
 
+      const minOpenPositionValue = BigNumber(
+        marketConfiguration.baseBorrowMin.toString()
+      ).dividedBy(BigNumber(10).pow(marketConfiguration.baseTokenDecimals));
+
       if (
-        userBorrowedModifiedRepay.minus(tokenAmount).lt(10) &&
+        userBorrowedModifiedRepay.minus(tokenAmount).lt(minOpenPositionValue) &&
         userBorrowedModifiedRepay.minus(tokenAmount).gt(0)
       ) {
-        return 'Your position cannot be less than $10. Please repay whole position or leave a position of at least 10 USDC open.';
+        return `Your position cannot be less than ${minOpenPositionValue.toFixed()} ${SYMBOL_TO_NAME[appConfig.assets[marketConfiguration.baseToken.bits]]}. Please repay whole position or leave a position of at least ${minOpenPositionValue.toFixed()} ${SYMBOL_TO_NAME[appConfig.assets[marketConfiguration.baseToken.bits]]} open.`;
       }
 
       if (tokenAmount.gt(userBorrowedModified))

--- a/apps/frontend/src/components/InputDialog/index.tsx
+++ b/apps/frontend/src/components/InputDialog/index.tsx
@@ -455,7 +455,7 @@ export const InputDialog = () => {
         userBorrowedModifiedRepay.minus(tokenAmount).lt(10) &&
         userBorrowedModifiedRepay.minus(tokenAmount).gt(0)
       ) {
-        return 'Your position cannot be less than $10. Please repay whole position or leave a position of at least $10 open.';
+        return 'Your position cannot be less than $10. Please repay whole position or leave a position of at least 10 USDC open.';
       }
 
       if (tokenAmount.gt(userBorrowedModified))

--- a/apps/frontend/src/components/Toasts/ErrorToast.tsx
+++ b/apps/frontend/src/components/Toasts/ErrorToast.tsx
@@ -12,10 +12,10 @@ export const ErrorToast = ({ error }: ErrorToastProps) => {
       return 'Transaction rejected by user.';
     }
     if (error.includes('Out of gas')) {
-      return 'Transaction failed, because wallet failed to calculate gas necessary. Please try again!';
+      return 'Transaction failed because the wallet failed to calculate the gas necessary. Please try again!';
     }
     if (error.includes('OutOfGas')) {
-      return 'Transaction failed, because wallet failed to calculate gas necessary. Please try again!';
+      return 'Transaction failed because the wallet failed to calculate the gas necessary. Please try again!';
     }
 
     if (error.includes('not enough coins to fit the target')) {

--- a/apps/frontend/src/components/Toasts/ErrorToast.tsx
+++ b/apps/frontend/src/components/Toasts/ErrorToast.tsx
@@ -12,7 +12,10 @@ export const ErrorToast = ({ error }: ErrorToastProps) => {
       return 'Transaction rejected by user.';
     }
     if (error.includes('Out of gas')) {
-      return 'Transaction failed. Out of gas';
+      return 'Transaction failed, because wallet failed to calculate gas necessary. Please try again!';
+    }
+    if (error.includes('OutOfGas')) {
+      return 'Transaction failed, because wallet failed to calculate gas necessary. Please try again!';
     }
 
     if (error.includes('not enough coins to fit the target')) {


### PR DESCRIPTION
- Do not let repays that lead to a position smaller than $10
- Change error msg for OutOfGas to make it more clear that this is a wallet problem and encourage users to try again.